### PR TITLE
Add Docker Compose support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ pip install -r requirements.txt
 python app.py
 ```
 
+3. **Run with Docker Compose** (requires Docker):
+```bash
+docker compose up -d
+```
+This command builds the image and starts the container. Named volumes `uploads` and `rooms` ensure files in `static/uploads` and `rooms.json` persist between container restarts.
+
 ## Default Credentials
 
 - Username: admin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.9'
+services:
+  slideroom:
+    build: .
+    ports:
+      - "5006:80"
+    volumes:
+      - uploads:/app/static/uploads
+      - rooms:/app/rooms.json
+    environment:
+      - PORT=80
+      - HOST=0.0.0.0
+volumes:
+  uploads:
+  rooms:


### PR DESCRIPTION
## Summary
- add Docker Compose configuration for containerized setup
- document Docker Compose usage in README

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684a3404fe44832db59bd50dec083079